### PR TITLE
Add the awscli package install and fix readme to point to jerry's garcon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cookbook-garcon-de-chef-training
 
-Cookbook to install Garcon De Chef Training tool and dependencies by Jerry Aldrich https://github.com/TheLunaticScripter/garcon-de-chef-training
+Cookbook to install Garcon De Chef Training tool and dependencies by Jerry Aldrich https://github.com/jerryaldrichiii/garcon-de-chef-training
 ================================================================================================================================================
 
 [![BuildStatus](https://travis-ci.org/TheLunaticScripter/cookbook-garcon-de-chef-training.svg?branch=master)](https://travis-ci.org/TheLunaticScripter/cookbook-garcon-de-chef-training)

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,3 +22,5 @@ execute 'unzip_terraform' do
 end
 
 package 'ruby'
+
+package 'awscli'


### PR DESCRIPTION
The aws cli tools are needed for terraform to run properly with garcon. Added them to the install.